### PR TITLE
GetTrades() now provide correct historical info

### DIFF
--- a/example_history.js
+++ b/example_history.js
@@ -13,6 +13,8 @@ const { ethers } = require("ethers");
     //                   GET POOL DATA
     // =============================================================
 
+    let archive = await sudo.hasNodeArchiveCapabilities()
+    console.log(archive)
     let utils = sudo.utils;
 
     const pool = sudo.getPool("0x451018623f2ea29a625ac5e051720eeac2b0e765"); //initiate random pool based on chain id

--- a/example_history.js
+++ b/example_history.js
@@ -15,6 +15,20 @@ const { ethers } = require("ethers");
 
     let utils = sudo.utils;
 
+    const pool = sudo.getPool("0x5caf332dca4e6c9e69d52f320c21e74845353db0"); //initiate random pool based on chain id
+
+    console.log(await pool.getCurve());
+    let trades = await pool.getTrades();
+    console.log(trades);
+
+    /*
+
+        const pool = sudo.getPool("0xb3041791fefe9284074713e4e14a6c4ddeeb57f9"); //initiate random pool based on chain id
+
+    console.log(await pool.getCurve())
+    let trades = await pool.getTradesOut();
+
+
     console.log("utils ", utils);
 
     let fee = utils.formatFee("0.01");
@@ -33,20 +47,6 @@ const { ethers } = require("ethers");
         ethers.utils.formatEther(i.newSpotPrice)
       );
     }
-    return;
-    const pool = sudo.getPool("0x5caf332dca4e6c9e69d52f320c21e74845353db0"); //initiate random pool based on chain id
-
-    console.log(await pool.getCurve());
-    let trades = await pool.getTrades();
-    console.log(trades);
-
-    /*
-
-        const pool = sudo.getPool("0xb3041791fefe9284074713e4e14a6c4ddeeb57f9"); //initiate random pool based on chain id
-
-    console.log(await pool.getCurve())
-    let trades = await pool.getTradesOut();
-    return
 */
   } catch (e) {
     console.log(e);

--- a/example_history.js
+++ b/example_history.js
@@ -15,7 +15,7 @@ const { ethers } = require("ethers");
 
     let utils = sudo.utils;
 
-    const pool = sudo.getPool("0x5caf332dca4e6c9e69d52f320c21e74845353db0"); //initiate random pool based on chain id
+    const pool = sudo.getPool("0x451018623f2ea29a625ac5e051720eeac2b0e765"); //initiate random pool based on chain id
 
     console.log(await pool.getCurve());
     let trades = await pool.getTrades();

--- a/src/ABIS/factory.json
+++ b/src/ABIS/factory.json
@@ -1,0 +1,517 @@
+[
+    {
+      "inputs": [
+        {
+          "internalType": "contract LSSVMPairEnumerableETH",
+          "name": "_enumerableETHTemplate",
+          "type": "address"
+        },
+        {
+          "internalType": "contract LSSVMPairMissingEnumerableETH",
+          "name": "_missingEnumerableETHTemplate",
+          "type": "address"
+        },
+        {
+          "internalType": "contract LSSVMPairEnumerableERC20",
+          "name": "_enumerableERC20Template",
+          "type": "address"
+        },
+        {
+          "internalType": "contract LSSVMPairMissingEnumerableERC20",
+          "name": "_missingEnumerableERC20Template",
+          "type": "address"
+        },
+        {
+          "internalType": "address payable",
+          "name": "_protocolFeeRecipient",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_protocolFeeMultiplier",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "contract ICurve",
+          "name": "bondingCurve",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "isAllowed",
+          "type": "bool"
+        }
+      ],
+      "name": "BondingCurveStatusUpdate",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "target",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "isAllowed",
+          "type": "bool"
+        }
+      ],
+      "name": "CallTargetStatusUpdate",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "poolAddress",
+          "type": "address"
+        }
+      ],
+      "name": "NFTDeposit",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "poolAddress",
+          "type": "address"
+        }
+      ],
+      "name": "NewPair",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newMultiplier",
+          "type": "uint256"
+        }
+      ],
+      "name": "ProtocolFeeMultiplierUpdate",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "recipientAddress",
+          "type": "address"
+        }
+      ],
+      "name": "ProtocolFeeRecipientUpdate",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "contract LSSVMRouter",
+          "name": "router",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "isAllowed",
+          "type": "bool"
+        }
+      ],
+      "name": "RouterStatusUpdate",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "poolAddress",
+          "type": "address"
+        }
+      ],
+      "name": "TokenDeposit",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        { "internalType": "contract ICurve", "name": "", "type": "address" }
+      ],
+      "name": "bondingCurveAllowed",
+      "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+      "name": "callAllowed",
+      "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_protocolFeeMultiplier",
+          "type": "uint256"
+        }
+      ],
+      "name": "changeProtocolFeeMultiplier",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address payable",
+          "name": "_protocolFeeRecipient",
+          "type": "address"
+        }
+      ],
+      "name": "changeProtocolFeeRecipient",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "contract ERC20",
+              "name": "token",
+              "type": "address"
+            },
+            {
+              "internalType": "contract IERC721",
+              "name": "nft",
+              "type": "address"
+            },
+            {
+              "internalType": "contract ICurve",
+              "name": "bondingCurve",
+              "type": "address"
+            },
+            {
+              "internalType": "address payable",
+              "name": "assetRecipient",
+              "type": "address"
+            },
+            {
+              "internalType": "enum LSSVMPair.PoolType",
+              "name": "poolType",
+              "type": "uint8"
+            },
+            { "internalType": "uint128", "name": "delta", "type": "uint128" },
+            { "internalType": "uint96", "name": "fee", "type": "uint96" },
+            { "internalType": "uint128", "name": "spotPrice", "type": "uint128" },
+            {
+              "internalType": "uint256[]",
+              "name": "initialNFTIDs",
+              "type": "uint256[]"
+            },
+            {
+              "internalType": "uint256",
+              "name": "initialTokenBalance",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct LSSVMPairFactory.CreateERC20PairParams",
+          "name": "params",
+          "type": "tuple"
+        }
+      ],
+      "name": "createPairERC20",
+      "outputs": [
+        {
+          "internalType": "contract LSSVMPairERC20",
+          "name": "pair",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "contract IERC721", "name": "_nft", "type": "address" },
+        {
+          "internalType": "contract ICurve",
+          "name": "_bondingCurve",
+          "type": "address"
+        },
+        {
+          "internalType": "address payable",
+          "name": "_assetRecipient",
+          "type": "address"
+        },
+        {
+          "internalType": "enum LSSVMPair.PoolType",
+          "name": "_poolType",
+          "type": "uint8"
+        },
+        { "internalType": "uint128", "name": "_delta", "type": "uint128" },
+        { "internalType": "uint96", "name": "_fee", "type": "uint96" },
+        { "internalType": "uint128", "name": "_spotPrice", "type": "uint128" },
+        {
+          "internalType": "uint256[]",
+          "name": "_initialNFTIDs",
+          "type": "uint256[]"
+        }
+      ],
+      "name": "createPairETH",
+      "outputs": [
+        {
+          "internalType": "contract LSSVMPairETH",
+          "name": "pair",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "contract ERC20", "name": "token", "type": "address" },
+        { "internalType": "address", "name": "recipient", "type": "address" },
+        { "internalType": "uint256", "name": "amount", "type": "uint256" }
+      ],
+      "name": "depositERC20",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "contract IERC721", "name": "_nft", "type": "address" },
+        { "internalType": "uint256[]", "name": "ids", "type": "uint256[]" },
+        { "internalType": "address", "name": "recipient", "type": "address" }
+      ],
+      "name": "depositNFTs",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "enumerableERC20Template",
+      "outputs": [
+        {
+          "internalType": "contract LSSVMPairEnumerableERC20",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "enumerableETHTemplate",
+      "outputs": [
+        {
+          "internalType": "contract LSSVMPairEnumerableETH",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "address", "name": "potentialPair", "type": "address" },
+        {
+          "internalType": "enum ILSSVMPairFactoryLike.PairVariant",
+          "name": "variant",
+          "type": "uint8"
+        }
+      ],
+      "name": "isPair",
+      "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "missingEnumerableERC20Template",
+      "outputs": [
+        {
+          "internalType": "contract LSSVMPairMissingEnumerableERC20",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "missingEnumerableETHTemplate",
+      "outputs": [
+        {
+          "internalType": "contract LSSVMPairMissingEnumerableETH",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "protocolFeeMultiplier",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "protocolFeeRecipient",
+      "outputs": [
+        { "internalType": "address payable", "name": "", "type": "address" }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "contract LSSVMRouter", "name": "", "type": "address" }
+      ],
+      "name": "routerStatus",
+      "outputs": [
+        { "internalType": "bool", "name": "allowed", "type": "bool" },
+        { "internalType": "bool", "name": "wasEverAllowed", "type": "bool" }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract ICurve",
+          "name": "bondingCurve",
+          "type": "address"
+        },
+        { "internalType": "bool", "name": "isAllowed", "type": "bool" }
+      ],
+      "name": "setBondingCurveAllowed",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address payable",
+          "name": "target",
+          "type": "address"
+        },
+        { "internalType": "bool", "name": "isAllowed", "type": "bool" }
+      ],
+      "name": "setCallAllowed",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract LSSVMRouter",
+          "name": "_router",
+          "type": "address"
+        },
+        { "internalType": "bool", "name": "isAllowed", "type": "bool" }
+      ],
+      "name": "setRouterAllowed",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "address", "name": "newOwner", "type": "address" }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "contract ERC20", "name": "token", "type": "address" },
+        { "internalType": "uint256", "name": "amount", "type": "uint256" }
+      ],
+      "name": "withdrawERC20ProtocolFees",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "withdrawETHProtocolFees",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    { "stateMutability": "payable", "type": "receive" }
+  ]

--- a/src/Factory.js
+++ b/src/Factory.js
@@ -1,0 +1,23 @@
+const ABI = require("./ABIS/factory.json");
+
+const ADDRESSES = {
+    1: "0xb16c1342E617A5B6E4b631EB114483FDB289c0A4", // mainnet
+    4: "0xcB1514FE29db064fa595628E0BFFD10cdf998F33", // rinkeby
+  };
+
+  function Factory(sudo, chainId = 1) {
+    this.sudo = sudo;
+    this.address = ADDRESSES[chainId];
+    this.chainId = chainId;
+    this.contract = new ethers.Contract(this.address, ABI, this.sudo.provider);
+  }
+
+  Factory.prototype.createPair = function () {
+      // todo
+  }
+
+  Factory.prototype.getAllPairs = function () {
+      // todo
+  }
+
+  module.exports = Factory;

--- a/src/Pool.js
+++ b/src/Pool.js
@@ -188,6 +188,7 @@ Pool.prototype.getTradesIn = async function () {
      console.log("INPUT", curveSimulation.outputValue.toString(), nfts.length,);*/
 
     //console.log("======== TX")
+    //console.log(curveSimulation)
     let t = {
       type: "NFT_IN_POOL",
       transactionHash: i.transactionHash,
@@ -195,6 +196,9 @@ Pool.prototype.getTradesIn = async function () {
       nfts: nfts,
       nbNfts: nfts.length,
       buyer: buyer,
+      lpFee: curveSimulation.lpFee.toString(),
+      protocolFee: curveSimulation.protocolFee.toString(),
+      outputValue: curveSimulation.outputValue.toString(),
       priceBefore: spotPriceBefore.toString(),
       priceAfter: spotPriceAfter.toString(),
       timestamp: b.timestamp,

--- a/src/Pool.js
+++ b/src/Pool.js
@@ -58,8 +58,8 @@ Pool.prototype.getAllHeldIds = async function () {
   return heldIds.map((i) => i.toString());
 };
 
-Pool.prototype.getSpotPrice = async function () {
-  let spotPrice = await this.contract.spotPrice();
+Pool.prototype.getSpotPrice = async function (blockNumber = "latest") {
+  let spotPrice = await this.contract.spotPrice({ blockTag: blockNumber });
   return spotPrice;
 };
 
@@ -69,9 +69,7 @@ Pool.prototype.getFee = async function (blockNumber = "latest") {
     return this.fee;
   }
   */
-  console.log("GETFEE", blockNumber)
   this.fee = await this.contract.fee({ blockTag: blockNumber });
-  console.log(this.fee.toString())
   return this.fee;
 };
 
@@ -190,7 +188,7 @@ Pool.prototype.getTradesIn = async function () {
     spotPriceBefore =
       spotPriceBefore.length > 0
         ? spotPriceBefore[spotPriceBefore.length - 1].args.newSpotPrice
-        : await this.getSpotPrice();
+        : await this.getSpotPrice(i.blockNumber - 1);
 
     // we get the spot Price after the swapIn event
     let spotPriceAfter = spotPrices.filter(function (p) {
@@ -199,7 +197,7 @@ Pool.prototype.getTradesIn = async function () {
     spotPriceAfter =
       spotPriceAfter.length > 0
         ? spotPriceAfter[0].args.newSpotPrice
-        : await this.getSpotPrice();
+        : await this.getSpotPrice(i.blockNumber);
 
     let b = await this.sudo.getBlock(i.blockNumber);
     let buyer = "";
@@ -314,7 +312,7 @@ Pool.prototype.getTradesOut = async function () {
     spotPriceBefore =
       spotPriceBefore.length > 0
         ? spotPriceBefore[spotPriceBefore.length - 1].args.newSpotPrice
-        : await this.getSpotPrice();
+        : await this.getSpotPrice(i.blockNumber - 1);
 
     // we get the spot Price after the swapIn event
     let spotPriceAfter = spotPrices.filter(function (p) {
@@ -324,7 +322,7 @@ Pool.prototype.getTradesOut = async function () {
     spotPriceAfter =
       spotPriceAfter.length > 0
         ? spotPriceAfter[0].args.newSpotPrice
-        : await this.getSpotPrice();
+        : await this.getSpotPrice(i.blockNumber);
 
     // let tx = await this.sudo.getTransaction(i.transactionHash);
     let b = await this.sudo.getBlock(i.blockNumber);

--- a/src/Pool.js
+++ b/src/Pool.js
@@ -199,6 +199,7 @@ Pool.prototype.getTradesIn = async function () {
       lpFee: curveSimulation.lpFee.toString(),
       protocolFee: curveSimulation.protocolFee.toString(),
       outputValue: curveSimulation.outputValue.toString(),
+      pricePerNft: curveSimulation.outputValue.div(nfts.length).toString(),
       priceBefore: spotPriceBefore.toString(),
       priceAfter: spotPriceAfter.toString(),
       timestamp: b.timestamp,
@@ -294,13 +295,17 @@ Pool.prototype.getTradesOut = async function () {
       nfts: nfts,
       nbNfts: nfts.length,
       buyer: buyer,
+      lpFee: curveSimulation.lpFee.toString(),
+      protocolFee: curveSimulation.protocolFee.toString(),
+      inputValue: curveSimulation.inputValue.toString(),
+      pricePerNft: curveSimulation.inputValue.div(nfts.length).toString(),
       priceBefore: spotPriceBefore.toString(),
       priceAfter: spotPriceAfter.toString(),
       timestamp: b.timestamp,
       pool: this.address,
       logIndex: i.logIndex,
     };
-    // console.log(t)
+     console.log(t)
     trades.push(t);
   }
   return trades;

--- a/src/Pool.js
+++ b/src/Pool.js
@@ -236,7 +236,7 @@ Pool.prototype.getTradesIn = async function () {
       timestamp: b.timestamp,
       pool: this.address,
     };
-    console.log(t)
+    // console.log(t)
     trades.push(t);
   }
   return trades;
@@ -363,7 +363,7 @@ Pool.prototype.getTradesOut = async function () {
       pool: this.address,
       logIndex: i.logIndex,
     };
-    console.log(t)
+    // console.log(t)
     trades.push(t);
   }
   return trades;

--- a/src/Pool.js
+++ b/src/Pool.js
@@ -154,8 +154,7 @@ Pool.prototype.getTradesIn = async function () {
       )
     })
     if (currentDelta.length > 0) {
-      console.log("#### FOUND DELTA UPDATE")
-      currentDelta = currentDelta[currentDelta.length - 1];
+      currentDelta = currentDelta[currentDelta.length - 1].args[0];
     } else {
       currentDelta = delta;
     }
@@ -167,8 +166,7 @@ Pool.prototype.getTradesIn = async function () {
       )
     })
     if (currentFee.length > 0) {
-      console.log("#### FOUND FEE UPDATE")
-      currentFee = currentFee[currentFee.length - 1];
+      currentFee = currentFee[currentFee.length - 1].args[0];
     } else {
       currentFee = fee;
     }
@@ -276,8 +274,7 @@ Pool.prototype.getTradesOut = async function () {
       )
     })
     if (currentDelta.length > 0) {
-      console.log("#### FOUND DELTA UPDATE")
-      currentDelta = currentDelta[currentDelta.length - 1];
+      currentDelta = currentDelta[currentDelta.length - 1].args[0];
     } else {
       currentDelta = delta;
     }
@@ -289,8 +286,7 @@ Pool.prototype.getTradesOut = async function () {
       )
     })
     if (currentFee.length > 0) {
-      console.log("#### FOUND FEE UPDATE")
-      currentFee = currentFee[currentFee.length - 1];
+      currentFee = currentFee[currentFee.length - 1].args[0];
     } else {
       currentFee = fee;
     }

--- a/src/Pool.js
+++ b/src/Pool.js
@@ -135,11 +135,44 @@ Pool.prototype.getTradesIn = async function () {
   let spotfilter = this.contract.filters.SpotPriceUpdate();
   let spotPrices = await this.contract.queryFilter(spotfilter);
 
+  let deltaUpdateFilter = this.contract.filters.DeltaUpdate();
+  let deltaUpdates = await this.contract.queryFilter(deltaUpdateFilter);
+
+  let feeUpdateFilter = this.contract.filters.FeeUpdate();
+  let feeUpdates = await this.contract.queryFilter(feeUpdateFilter);
+
   let nft = await this.getNFTContract();
   let intransfersfilter = nft.filters.Transfer(null, this.address);
   let intransfers = await nft.queryFilter(intransfersfilter);
 
   for (const i of inevents) {
+
+    let currentDelta = deltaUpdates.filter(function (u) {
+      return (
+        u.blockNumber <= i.blockNumber || 
+        u.blockNumber <= i.blockNumber && u.logIndex < i.logIndex
+      )
+    })
+    if (currentDelta.length > 0) {
+      console.log("#### FOUND DELTA UPDATE")
+      currentDelta = currentDelta[currentDelta.length - 1];
+    } else {
+      currentDelta = delta;
+    }
+
+    let currentFee = feeUpdates.filter(function (f) {
+      return (
+        f.blockNumber <= i.blockNumber || 
+        f.blockNumber <= i.blockNumber && f.logIndex < i.logIndex
+      )
+    })
+    if (currentFee.length > 0) {
+      console.log("#### FOUND FEE UPDATE")
+      currentFee = currentFee[currentFee.length - 1];
+    } else {
+      currentFee = fee;
+    }
+
     // We get the spot price before the swapIn event
     let spotPriceBefore = spotPrices.filter(function (p) {
       return (
@@ -176,8 +209,8 @@ Pool.prototype.getTradesIn = async function () {
       });
     let curveSimulation = await this.sudo.utils.getSellInfo(
       curveType,
-      fee,
-      delta,
+      currentFee,
+      currentDelta,
       spotPriceBefore,
       nfts.length
     );
@@ -188,6 +221,8 @@ Pool.prototype.getTradesIn = async function () {
       nfts: nfts,
       nbNfts: nfts.length,
       buyer: buyer,
+      fee: currentFee.toString(),
+      delta: delta.toString(),
       lpFee: curveSimulation.lpFee.toString(),
       protocolFee: curveSimulation.protocolFee.toString(),
       outputValue: curveSimulation.outputValue.toString(),
@@ -197,7 +232,7 @@ Pool.prototype.getTradesIn = async function () {
       timestamp: b.timestamp,
       pool: this.address,
     };
-    //console.log(t)
+    console.log(t)
     trades.push(t);
   }
   return trades;

--- a/src/Pool.js
+++ b/src/Pool.js
@@ -157,13 +157,11 @@ Pool.prototype.getTradesIn = async function () {
     let spotPriceAfter = spotPrices.filter(function (p) {
       return p.transactionHash == i.transactionHash && p.logIndex < i.logIndex;
     });
-    //console.log("price after == ", spotPriceAfter)
     spotPriceAfter =
       spotPriceAfter.length > 0
         ? spotPriceAfter[0].args.newSpotPrice
         : await this.getSpotPrice();
 
-    // let tx = await this.sudo.getTransaction(i.transactionHash);
     let b = await this.sudo.getBlock(i.blockNumber);
     let buyer = "";
     let nfts = intransfers
@@ -183,12 +181,6 @@ Pool.prototype.getTradesIn = async function () {
       spotPriceBefore,
       nfts.length
     );
-    /*console.log("SELL")
-     console.log(i.transactionHash)
-     console.log("INPUT", curveSimulation.outputValue.toString(), nfts.length,);*/
-
-    //console.log("======== TX")
-    //console.log(curveSimulation)
     let t = {
       type: "NFT_IN_POOL",
       transactionHash: i.transactionHash,
@@ -271,7 +263,6 @@ Pool.prototype.getTradesOut = async function () {
       .map(function (t) {
         return t.args.tokenId.toString();
       });
-    //console.log("CURVE PARAMS:::: ", curveType, ethers.utils.formatEther(fee), ethers.utils.formatEther(delta), ethers.utils.formatEther(spotPriceBefore), nfts.length)
     let curveSimulation = await this.sudo.utils.getBuyInfo(
       curveType,
       fee,
@@ -279,15 +270,6 @@ Pool.prototype.getTradesOut = async function () {
       spotPriceBefore,
       nfts.length
     );
-    /* console.log("BUY")
-     console.log(i.transactionHash)
-    console.log("VOLUME", volume.toString())
-     console.log("FEE ", lpFees.toString())
-     console.log("======== TX")
-     console.log("BEFORE", ethers.utils.formatEther(spotPriceBefore))
-     console.log("AFTER", ethers.utils.formatEther(spotPriceAfter), ethers.utils.formatEther(curveSimulation.newSpotPrice))
-     console.log("INPUT", ethers.utils.formatEther(curveSimulation.inputValue), nfts.length,);
-    console.log("PROTOCOL FEE", curveSimulation.protocolFee.toString()) */
     let t = {
       type: "NFT_OUT_POOL",
       transactionHash: i.transactionHash,
@@ -305,7 +287,7 @@ Pool.prototype.getTradesOut = async function () {
       pool: this.address,
       logIndex: i.logIndex,
     };
-     console.log(t)
+    // console.log(t)
     trades.push(t);
   }
   return trades;

--- a/src/Sudoswap.js
+++ b/src/Sudoswap.js
@@ -10,7 +10,7 @@ const TRANSACTION_CACHE_SIZE = 100;
 
 function Sudoswap(web3Provider, pKey = null) {
   this.connectedAddress = null;
-
+  this.isArchive = "UNKNOWN"
   this.isWeb3Provider = false;
   if (typeof web3Provider == "string") {
     if (web3Provider.startsWith("http")) {
@@ -51,6 +51,21 @@ function Sudoswap(web3Provider, pKey = null) {
     maxSize: TRANSACTION_CACHE_SIZE,
     maxArgs: 1,
   });
+}
+
+Sudoswap.prototype.hasNodeArchiveCapabilities = async function () {
+  if (this.isArchive == "UNKNOWN") {
+    this.isArchive = false;
+    try {
+      let testResult = await this.provider.getBalance("0xe5Fb31A5CaEE6a96de393bdBF89FBe65fe125Bb3", 1);
+      if (testResult.toString() == "1000000000000000000000") {
+        this.isArchive = true;
+      }
+    } catch (error) {
+      // console.log(error)
+    }
+  }
+  return this.isArchive;
 }
 
 Sudoswap.prototype.getSigner = async function () {


### PR DESCRIPTION
for eg: 
```
{
  type: 'NFT_OUT_POOL',
  transactionHash: '0x843a0612826b6820383fd8b5b08e97c8645221ee8f9622bcf3ea9ed7c1bfebc1',
  blockNumber: 15391750,
  nfts: [ '4024' ],
  nbNfts: 1,
  buyer: '0x095aca033F31708Bf2542F15f7C5AEAFFA9B8e0b',
  fee: '30000000000000000',
  delta: '1100000000000000000',
  lpFee: '103321068658202847',
  protocolFee: '17220178109700474',
  inputValue: '3564576868707998237',
  pricePerNft: '3564576868707998237',
  priceBefore: '3130941474490995379',
  priceAfter: '3571014492753623300',
  timestamp: 1661191376,
  pool: '0x451018623f2ea29a625ac5e051720eeac2b0e765',
  logIndex: 130
}
{
  type: 'NFT_IN_POOL',
  transactionHash: '0xabd28282f9f3b3b074e57c0a7fbb0adbf67def90b3dddba43cd088aef957fe65',
  blockNumber: 15391959,
  nfts: [ '7309' ],
  nbNfts: 1,
  buyer: '0x451018623F2EA29A625Ac5e051720eEAc2b0E765',
  fee: '30000000000000000',
  delta: '1030000000000000000',
  lpFee: '117843478260869568',
  protocolFee: '19640579710144928',
  outputValue: '3790631884057971129',
  pricePerNft: '3790631884057971129',
  priceBefore: '3928115942028985625',
  priceAfter: '3571014492753623291',
  timestamp: 1661194031,
  pool: '0x451018623f2ea29a625ac5e051720eeac2b0e765'
}
```